### PR TITLE
Allow User Defined Metadata for File Uploads

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function apply(options, compiler) {
             if(!error){
                 var assets = utils.getAssets(compilation);
                 assets.forEach(function(asset) {
-                    blobService.createBlockBlobFromText(options.container.name, asset.filePath, asset.fileContent, function(error, result, response) {
+                    blobService.createBlockBlobFromText(options.container.name, asset.filePath, asset.fileContent, { contentSettings: options.metadata }, function(error, result, response) {
                     if(!error){
                         console.log("successfully uploaded '" + asset.filePath + "' to container '" + options.container.name + "'");
                     } else {


### PR DESCRIPTION
This allows the script to set cache control and content type headers. Example usage:

```
plugins: [new AzureStorageWebpackPlugin({
        blobService: ['blobstore', 'supersecret'],
        container: { name: 'mycontainer', options: { publicAccessLevel: 'blob' } },
        metadata: {
            cacheControl: 'public, max-age=31536000, s-maxage=31536000',
            contentType: 'application/javascript'
        }
    })]```

Thoughts?