### PR TITLE
Passing content Type as function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,52 @@ var webpackConfig = {
 };
 ```
 
-This will upload the `dist/bundle.js` file to the specified container.  
+```javascript
+const AzureStorageWebpackPlugin = require('azure-storage-webpack-plugin');
+
+const getContentType = (fileName = '') => {
+    const fileExt =  path.extname(fileName);
+    switch(fileExt) {
+        case '.js': {
+            return 'application/javascript';
+        }
+        case '.css': {
+            return 'text/css';
+        }
+        default: {
+            return ''
+        }
+    }
+};
+
+
+const webpackConfig = {
+  entry: {
+    widget: 'js/path',
+    widgetCss: 'css/path'
+  },
+  output: {
+    path: 'dist',
+    filename: 'js/[name].js'
+  },
+  plugins: [
+    new AzureStorageWebpackPlugin({
+        blobService: ['storageaccountname','key'],
+        container: { name: 'containername', options: { publicAccessLevel : 'blob' }},
+        
+        // Optionally set cache control and content type header
+        metadata: {
+          cacheControl: 'public, max-age=31536000, s-maxage=31536000',
+          contentType: getContentType
+        }
+    }),
+    // CSS Extraction Plugin from js
+  ]
+};
+```
+
+This will upload the `dist/widget.js` file to the specified container with the contentType `application/javascript`.
+This will upload the `dist/widgetCss.css` file to the specified container with the contentType `text/css`.
 Files contained in folders will also be uploaded following the respective folder structure.  
 
 **NOTE:** This plugin is not intented to be used when in a _hot-reloading_ Webpack setup.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ var webpackConfig = {
 };
 ```
 
+This will upload the `dist/widget.js` file to the specified container
+
 ```javascript
 const AzureStorageWebpackPlugin = require('azure-storage-webpack-plugin');
 const path = require('path');
@@ -85,6 +87,7 @@ const webpackConfig = {
 
 This will upload the `dist/widget.js` file to the specified container with the contentType `application/javascript`.
 This will upload the `dist/widgetCss.css` file to the specified container with the contentType `text/css`.
+
 Files contained in folders will also be uploaded following the respective folder structure.  
 
 **NOTE:** This plugin is not intented to be used when in a _hot-reloading_ Webpack setup.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ var webpackConfig = {
 
 ```javascript
 const AzureStorageWebpackPlugin = require('azure-storage-webpack-plugin');
+const path = require('path');
 
 const getContentType = (fileName = '') => {
     const fileExt =  path.extname(fileName);

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ var webpackConfig = {
 };
 ```
 
-This will upload the `dist/widget.js` file to the specified container
+This will upload the `dist/bundle.js` file to the specified container
 
 ```javascript
 const AzureStorageWebpackPlugin = require('azure-storage-webpack-plugin');

--- a/index.js
+++ b/index.js
@@ -22,17 +22,18 @@ function apply(options, compiler) {
                 var assets = utils.getAssets(compilation);
                 assets.forEach(function(asset) {
                     blobService.createBlockBlobFromText(options.container.name, asset.filePath, asset.fileContent, { contentSettings: getContentSettings(options.metadata, asset.filePath) }, function(error, result, response) {
-                    if(!error){
-                        console.log("successfully uploaded '" + asset.filePath + "' to container '" + options.container.name + "'");
-                    } else {
-                        console.error(error);
-                    }
+                        if(!error){
+                            console.log("successfully uploaded '" + asset.filePath + "' to container '" + options.container.name + "'");
+                        } else {
+                            console.error(error);
+                        }
                     });
                 });
 
             } else {
                 console.error(error);
             }
+            callback();
         });
     });
 }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,12 @@ var azure = require('azure-storage');
 
 var utils = require('./lib/utils');
 
+function getContentSettings(metadata, filePath) {
+    var contentType = metadata.contentType;
+    metadata.contentType = typeof contentType === 'function' ? contentType(filePath) : contentType;
+    return metadata;
+}
+
 function apply(options, compiler) {
 
     // When assets are being emmited (not yet on file system)
@@ -12,7 +18,7 @@ function apply(options, compiler) {
             if(!error){
                 var assets = utils.getAssets(compilation);
                 assets.forEach(function(asset) {
-                    blobService.createBlockBlobFromText(options.container.name, asset.filePath, asset.fileContent, { contentSettings: options.metadata }, function(error, result, response) {
+                    blobService.createBlockBlobFromText(options.container.name, asset.filePath, asset.fileContent, { contentSettings: getContentSettings(options.metadata, asset.filePath) }, function(error, result, response) {
                     if(!error){
                         console.log("successfully uploaded '" + asset.filePath + "' to container '" + options.container.name + "'");
                     } else {

--- a/index.js
+++ b/index.js
@@ -2,10 +2,13 @@ var azure = require('azure-storage');
 
 var utils = require('./lib/utils');
 
-function getContentSettings(metadata, filePath) {
-    var contentType = metadata.contentType;
-    metadata.contentType = typeof contentType === 'function' ? contentType(filePath) : contentType;
-    return metadata;
+const getContentSettings = (metadata = {}, filePath) => {
+    const { contentType = '' } = metadata;
+    return {
+        ...metadata,
+        contentType: typeof contentType === 'function' ? contentType(filePath)
+            : contentType
+    }
 }
 
 function apply(options, compiler) {


### PR DESCRIPTION
We need to set ContentType of css as well as js while pushing the file on azure blob storage. We need to set the content type for each file. I have passed contentType as a function and filePath as the argument. One can pass the contentType as function and set the contentType on the basis of their file. 